### PR TITLE
Add optional page loader and custom cursor

### DIFF
--- a/assets/custom-pointer.css
+++ b/assets/custom-pointer.css
@@ -1,0 +1,3 @@
+body {
+  cursor: url('https://cdn.shopify.com/s/files/1/0823/0541/7515/files/normal-select.png?v=1703882881'), auto;
+}

--- a/assets/loader.css
+++ b/assets/loader.css
@@ -1,0 +1,27 @@
+#PageLoader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgb(var(--color-background));
+  z-index: 9999;
+  flex-direction: column;
+}
+
+#PageLoader.hidden {
+  display: none;
+}
+
+#PageLoader img {
+  max-width: 120px;
+}
+
+#PageLoader .loader-text {
+  margin-top: 1rem;
+  font-size: 1.4rem;
+  color: rgb(var(--color-foreground));
+}

--- a/assets/loader.js
+++ b/assets/loader.js
@@ -1,0 +1,4 @@
+window.addEventListener('load', () => {
+  const loader = document.getElementById('PageLoader');
+  if (loader) loader.classList.add('hidden');
+});

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -256,6 +256,7 @@
     {% endstyle %}
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
+    {{ 'custom-pointer.css' | asset_url | stylesheet_tag }}
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}

--- a/sections/loader.liquid
+++ b/sections/loader.liquid
@@ -1,0 +1,41 @@
+{{ 'loader.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'loader.js' | asset_url }}" defer></script>
+
+<div id="PageLoader">
+  {% if section.settings.show_logo and section.settings.logo != blank %}
+    <img src="{{ section.settings.logo | image_url }}" alt="{{ shop.name }}">
+  {% endif %}
+  <span class="loader-text">{{ section.settings.heading }}</span>
+</div>
+
+{% schema %}
+{
+  "name": "Page Loader",
+  "tag": "section",
+  "class": "page-loader",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Page Loader"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_logo",
+      "label": "Show logo",
+      "default": true
+    },
+    {
+      "type": "image_picker",
+      "id": "logo",
+      "label": "Logo image"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Page Loader"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- implement `loader.liquid` section so a store owner can display a logo and "Page Loader" text while the page loads
- show the loader until the window `load` event fires
- add `custom-pointer.css` to use the provided cursor across the site